### PR TITLE
Possibility to use existing related objects on create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 0.1.4
-* Add support for GenericRelation (@tjwatch)
+* Add support for GenericRelation (@tjwalch)
 
 ## 0.1.3
-* Handle when serializer has a field that's not on the model #5 (@tjwatch)
+* Handle when serializer has a field that's not on the model #5 (@tjwalch)
 
 ## 0.1.2
 * Fix problem with null values for reverse relations

--- a/README.md
+++ b/README.md
@@ -190,6 +190,26 @@ print(user_serializer.data)
 }
 ```
 
+It is also possible to pass through values to nested serializers from the call 
+to the base serializer's `save` method. These `kwargs` must be of type `dict`. E g:
+
+```python
+# user_serializer created with 'data' as above
+user = user_serializer.save(
+    profile={
+        'access_key': {'key': 'key2'},
+    },
+)
+print(user.profile.access_key.key)
+```
+
+```python
+'key2'
+```
+
+N b that the same value will be used for all nested instances.
+
+
 Authors
 =======
 2014-2017, beda.software

--- a/drf_writable_nested/mixins.py
+++ b/drf_writable_nested/mixins.py
@@ -116,15 +116,12 @@ class BaseNestedModelSerializer(serializers.ModelSerializer):
 
             new_related_instances = []
             for data in related_data:
-                if data.get('pk') is None:
-                    serializer = self._get_serializer_for_field(
-                        field, data=data)
-                else:
-                    pk = data.get('pk')
-                    obj = instances[pk]
-                    serializer = self._get_serializer_for_field(
-                        field, instance=obj, data=data)
-
+                obj = instances.get(data.get('pk'))
+                serializer = self._get_serializer_for_field(
+                    field,
+                    instance=obj,
+                    data=data,
+                )
                 serializer.is_valid(raise_exception=True)
                 related_instance = serializer.save(**save_kwargs)
                 data.setdefault('pk', related_instance.pk)

--- a/tests/models.py
+++ b/tests/models.py
@@ -43,3 +43,14 @@ class TaggedItem(models.Model):
 class Team(models.Model):
     name = models.CharField(max_length=100)
     members = models.ManyToManyField(User)
+
+
+class CustomPK(models.Model):
+    slug = models.SlugField(
+        primary_key=True,
+    )
+    user = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name='custompks',
+    )

--- a/tests/models.py
+++ b/tests/models.py
@@ -38,3 +38,8 @@ class Tag(models.Model):
 
 class TaggedItem(models.Model):
     tags = GenericRelation(Tag)
+
+
+class Team(models.Model):
+    name = models.CharField(max_length=100)
+    members = models.ManyToManyField(User)

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -94,3 +94,25 @@ class TeamSerializer(WritableNestedModelSerializer):
             'members',
             'name',
         )
+
+
+class CustomPKSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = models.CustomPK
+        fields = (
+            'slug',
+        )
+
+
+class UserWithCustomPKSerializer(WritableNestedModelSerializer):
+    custompks = CustomPKSerializer(
+        many=True,
+    )
+
+    class Meta:
+        model = models.User
+        fields = (
+            'custompks',
+            'username',
+        )

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -83,3 +83,14 @@ class TaggedItemSerializer(WritableNestedModelSerializer):
         fields = (
             'tags',
         )
+
+
+class TeamSerializer(WritableNestedModelSerializer):
+    members = UserSerializer(many=True)
+
+    class Meta:
+        model = models.Team
+        fields = (
+            'members',
+            'name',
+        )

--- a/tests/test_writable_nested_model_serializer.py
+++ b/tests/test_writable_nested_model_serializer.py
@@ -466,3 +466,18 @@ class WritableNestedModelSerializerTest(TestCase):
         access_key.refresh_from_db()
         self.assertEqual(access_key, user.profile.access_key)
         self.assertEqual('new-key', access_key.key)
+
+    def test_create_with_save_kwargs(self):
+        data = self.get_initial_data()
+        serializer = serializers.UserSerializer(data=data)
+        serializer.is_valid(raise_exception=True)
+        user = serializer.save(
+            profile={
+                'access_key': {'key': 'key2'},
+                'sites': {'url': 'http://test.com'}
+            },
+        )
+        self.assertEqual('key2', user.profile.access_key.key)
+        sites = list(user.profile.sites.all())
+        self.assertEqual('http://test.com', sites[0].url)
+        self.assertEqual('http://test.com', sites[1].url)

--- a/tests/test_writable_nested_model_serializer.py
+++ b/tests/test_writable_nested_model_serializer.py
@@ -447,3 +447,22 @@ class WritableNestedModelSerializerTest(TestCase):
         self.assertEqual('image-1.png', avatar.image)
         self.assertNotEqual(new_user.profile, profile)
         self.assertEqual(new_user.profile, avatar.profile)
+
+    def test_create_with_existing_direct_fk_object(self):
+        access_key = models.AccessKey.objects.create(
+            key='the-key',
+        )
+        serializer = serializers.AccessKeySerializer(
+            instance=access_key,
+        )
+        data = self.get_initial_data()
+        data['profile']['access_key'] = serializer.data
+        data['profile']['access_key']['key'] = 'new-key'
+        serializer = serializers.UserSerializer(
+            data=data,
+        )
+        self.assertTrue(serializer.is_valid())
+        user = serializer.save()
+        access_key.refresh_from_db()
+        self.assertEqual(access_key, user.profile.access_key)
+        self.assertEqual('new-key', access_key.key)

--- a/tests/test_writable_nested_model_serializer.py
+++ b/tests/test_writable_nested_model_serializer.py
@@ -1,7 +1,9 @@
 from django.test import TestCase
 
-from .models import Site, Avatar, User, Profile, AccessKey, Tag, TaggedItem
-from .serializers import UserSerializer, CustomSerializer, TaggedItemSerializer
+from . import (
+    models,
+    serializers,
+)
 
 
 class WritableNestedModelSerializerTest(TestCase):
@@ -32,7 +34,7 @@ class WritableNestedModelSerializerTest(TestCase):
         }
 
     def test_create(self):
-        serializer = UserSerializer(data=self.get_initial_data())
+        serializer = serializers.UserSerializer(data=self.get_initial_data())
         serializer.is_valid(raise_exception=True)
         user = serializer.save()
 
@@ -55,28 +57,28 @@ class WritableNestedModelSerializerTest(TestCase):
         )
 
         # Check instances count
-        self.assertEqual(User.objects.count(), 1)
-        self.assertEqual(Profile.objects.count(), 1)
-        self.assertEqual(Site.objects.count(), 2)
-        self.assertEqual(Avatar.objects.count(), 2)
-        self.assertEqual(AccessKey.objects.count(), 1)
+        self.assertEqual(models.User.objects.count(), 1)
+        self.assertEqual(models.Profile.objects.count(), 1)
+        self.assertEqual(models.Site.objects.count(), 2)
+        self.assertEqual(models.Avatar.objects.count(), 2)
+        self.assertEqual(models.AccessKey.objects.count(), 1)
 
     def test_create_with_not_specified_reverse_one_to_one(self):
-        serializer = UserSerializer(data={'username': 'test',})
+        serializer = serializers.UserSerializer(data={'username': 'test',})
         serializer.is_valid(raise_exception=True)
         user = serializer.save()
-        self.assertFalse(Profile.objects.filter(user=user).exists())
+        self.assertFalse(models.Profile.objects.filter(user=user).exists())
 
     def test_create_with_empty_reverse_one_to_one(self):
-        serializer = UserSerializer(data={'username': 'test', 'profile': None})
+        serializer = serializers.UserSerializer(data={'username': 'test', 'profile': None})
         serializer.is_valid(raise_exception=True)
         user = serializer.save()
-        self.assertFalse(Profile.objects.filter(user=user).exists())
+        self.assertFalse(models.Profile.objects.filter(user=user).exists())
 
     def test_create_with_custom_field(self):
         data = self.get_initial_data()
         data['custom_field'] = 'custom value'
-        serializer = CustomSerializer(data=data)
+        serializer = serializers.CustomSerializer(data=data)
         serializer.is_valid(raise_exception=True)
         user = serializer.save()
         self.assertIsNotNone(user)
@@ -90,30 +92,30 @@ class WritableNestedModelSerializerTest(TestCase):
                 {'tag': next_tag},
             ],
         }
-        serializer = TaggedItemSerializer(data=data)
+        serializer = serializers.TaggedItemSerializer(data=data)
         serializer.is_valid(raise_exception=True)
         item = serializer.save()
         self.assertIsNotNone(item)
-        self.assertEqual(2, Tag.objects.count())
+        self.assertEqual(2, models.Tag.objects.count())
         self.assertEqual(first_tag, item.tags.all()[0].tag)
         self.assertEqual(next_tag, item.tags.all()[1].tag)
 
     def test_update(self):
-        serializer = UserSerializer(data=self.get_initial_data())
+        serializer = serializers.UserSerializer(data=self.get_initial_data())
         serializer.is_valid(raise_exception=True)
         user = serializer.save()
 
         # Check instances count
-        self.assertEqual(User.objects.count(), 1)
-        self.assertEqual(Profile.objects.count(), 1)
-        self.assertEqual(Site.objects.count(), 2)
-        self.assertEqual(Avatar.objects.count(), 2)
+        self.assertEqual(models.User.objects.count(), 1)
+        self.assertEqual(models.Profile.objects.count(), 1)
+        self.assertEqual(models.Site.objects.count(), 2)
+        self.assertEqual(models.Avatar.objects.count(), 2)
 
         # Update
         user_pk = user.pk
         profile_pk = user.profile.pk
 
-        serializer = UserSerializer(
+        serializer = serializers.UserSerializer(
             instance=user,
             data={
                 'pk': user_pk,
@@ -165,20 +167,20 @@ class WritableNestedModelSerializerTest(TestCase):
         )
 
         # Check instances count
-        self.assertEqual(User.objects.count(), 1)
-        self.assertEqual(Profile.objects.count(), 1)
-        self.assertEqual(Site.objects.count(), 1)
-        self.assertEqual(Avatar.objects.count(), 3)
+        self.assertEqual(models.User.objects.count(), 1)
+        self.assertEqual(models.Profile.objects.count(), 1)
+        self.assertEqual(models.Site.objects.count(), 1)
+        self.assertEqual(models.Avatar.objects.count(), 3)
         # Access key shouldn't be removed because it is FK
-        self.assertEqual(AccessKey.objects.count(), 1)
+        self.assertEqual(models.AccessKey.objects.count(), 1)
 
     def test_update_with_empty_reverse_one_to_one(self):
-        serializer = UserSerializer(data=self.get_initial_data())
+        serializer = serializers.UserSerializer(data=self.get_initial_data())
         serializer.is_valid(raise_exception=True)
         user = serializer.save()
         self.assertIsNotNone(user.profile)
 
-        serializer = UserSerializer(
+        serializer = serializers.UserSerializer(
             instance=user,
             data={
                 'pk': user.pk,
@@ -188,25 +190,25 @@ class WritableNestedModelSerializerTest(TestCase):
         )
         serializer.is_valid(raise_exception=True)
         user = serializer.save()
-        self.assertFalse(Profile.objects.filter(user=user).exists())
+        self.assertFalse(models.Profile.objects.filter(user=user).exists())
 
     def test_partial_update(self):
-        serializer = UserSerializer(data=self.get_initial_data())
+        serializer = serializers.UserSerializer(data=self.get_initial_data())
         serializer.is_valid(raise_exception=True)
         user = serializer.save()
 
         # Check instances count
-        self.assertEqual(User.objects.count(), 1)
-        self.assertEqual(Profile.objects.count(), 1)
-        self.assertEqual(Site.objects.count(), 2)
-        self.assertEqual(Avatar.objects.count(), 2)
-        self.assertEqual(AccessKey.objects.count(), 1)
+        self.assertEqual(models.User.objects.count(), 1)
+        self.assertEqual(models.Profile.objects.count(), 1)
+        self.assertEqual(models.Site.objects.count(), 2)
+        self.assertEqual(models.Avatar.objects.count(), 2)
+        self.assertEqual(models.AccessKey.objects.count(), 1)
 
         # Partial update
         user_pk = user.pk
         profile_pk = user.profile.pk
 
-        serializer = UserSerializer(
+        serializer = serializers.UserSerializer(
             instance=user,
             partial=True,
             data={
@@ -238,30 +240,30 @@ class WritableNestedModelSerializerTest(TestCase):
         )
 
         # Check instances count
-        self.assertEqual(User.objects.count(), 1)
-        self.assertEqual(Profile.objects.count(), 1)
-        self.assertEqual(Site.objects.count(), 2)
-        self.assertEqual(Avatar.objects.count(), 2)
-        self.assertEqual(AccessKey.objects.count(), 1)
+        self.assertEqual(models.User.objects.count(), 1)
+        self.assertEqual(models.Profile.objects.count(), 1)
+        self.assertEqual(models.Site.objects.count(), 2)
+        self.assertEqual(models.Avatar.objects.count(), 2)
+        self.assertEqual(models.AccessKey.objects.count(), 1)
 
     def test_partial_update_direct_fk(self):
-        serializer = UserSerializer(data=self.get_initial_data())
+        serializer = serializers.UserSerializer(data=self.get_initial_data())
         serializer.is_valid(raise_exception=True)
         user = serializer.save()
 
         # Check instances count
-        self.assertEqual(User.objects.count(), 1)
-        self.assertEqual(Profile.objects.count(), 1)
-        self.assertEqual(Site.objects.count(), 2)
-        self.assertEqual(Avatar.objects.count(), 2)
-        self.assertEqual(AccessKey.objects.count(), 1)
+        self.assertEqual(models.User.objects.count(), 1)
+        self.assertEqual(models.Profile.objects.count(), 1)
+        self.assertEqual(models.Site.objects.count(), 2)
+        self.assertEqual(models.Avatar.objects.count(), 2)
+        self.assertEqual(models.AccessKey.objects.count(), 1)
 
         # Partial update
         user_pk = user.pk
         profile_pk = user.profile.pk
         access_key_pk = user.profile.access_key.pk
 
-        serializer = UserSerializer(
+        serializer = serializers.UserSerializer(
             instance=user,
             partial=True,
             data={
@@ -290,29 +292,29 @@ class WritableNestedModelSerializerTest(TestCase):
         self.assertEqual(access_key.pk, access_key_pk)
 
         # Check instances count
-        self.assertEqual(User.objects.count(), 1)
-        self.assertEqual(Profile.objects.count(), 1)
-        self.assertEqual(Site.objects.count(), 2)
-        self.assertEqual(Avatar.objects.count(), 2)
-        self.assertEqual(AccessKey.objects.count(), 1)
+        self.assertEqual(models.User.objects.count(), 1)
+        self.assertEqual(models.Profile.objects.count(), 1)
+        self.assertEqual(models.Site.objects.count(), 2)
+        self.assertEqual(models.Avatar.objects.count(), 2)
+        self.assertEqual(models.AccessKey.objects.count(), 1)
 
     def test_nested_partial_update(self):
-        serializer = UserSerializer(data=self.get_initial_data())
+        serializer = serializers.UserSerializer(data=self.get_initial_data())
         serializer.is_valid(raise_exception=True)
         user = serializer.save()
 
         # Check instances count
-        self.assertEqual(User.objects.count(), 1)
-        self.assertEqual(Profile.objects.count(), 1)
-        self.assertEqual(Site.objects.count(), 2)
-        self.assertEqual(Avatar.objects.count(), 2)
-        self.assertEqual(AccessKey.objects.count(), 1)
+        self.assertEqual(models.User.objects.count(), 1)
+        self.assertEqual(models.Profile.objects.count(), 1)
+        self.assertEqual(models.Site.objects.count(), 2)
+        self.assertEqual(models.Avatar.objects.count(), 2)
+        self.assertEqual(models.AccessKey.objects.count(), 1)
 
         # Partial update
         user_pk = user.pk
         profile_pk = user.profile.pk
 
-        serializer = UserSerializer(
+        serializer = serializers.UserSerializer(
             instance=user,
             partial=True,
             data={
@@ -349,16 +351,16 @@ class WritableNestedModelSerializerTest(TestCase):
         )
 
         # Check instances count
-        self.assertEqual(User.objects.count(), 1)
-        self.assertEqual(Profile.objects.count(), 1)
-        self.assertEqual(Site.objects.count(), 2)
-        self.assertEqual(Avatar.objects.count(), 2)
+        self.assertEqual(models.User.objects.count(), 1)
+        self.assertEqual(models.Profile.objects.count(), 1)
+        self.assertEqual(models.Site.objects.count(), 2)
+        self.assertEqual(models.Avatar.objects.count(), 2)
         # Old access key shouldn't be deleted
-        self.assertEqual(AccessKey.objects.count(), 2)
+        self.assertEqual(models.AccessKey.objects.count(), 2)
 
     def test_update_with_generic_relation(self):
-        item = TaggedItem.objects.create()
-        serializer = TaggedItemSerializer(
+        item = models.TaggedItem.objects.create()
+        serializer = serializers.TaggedItemSerializer(
             instance=item,
             data={
                 'tags': [{
@@ -371,7 +373,7 @@ class WritableNestedModelSerializerTest(TestCase):
         item.refresh_from_db()
         self.assertEqual(1, item.tags.count())
 
-        serializer = TaggedItemSerializer(
+        serializer = serializers.TaggedItemSerializer(
             instance=item,
             data={
                 'tags': [{
@@ -385,7 +387,7 @@ class WritableNestedModelSerializerTest(TestCase):
         item.refresh_from_db()
         self.assertEqual('the_new_tag', item.tags.get().tag)
 
-        serializer = TaggedItemSerializer(
+        serializer = serializers.TaggedItemSerializer(
             instance=item,
             data={
                 'tags': [{


### PR DESCRIPTION
In a lot of cases you need to be able to add and maybe update an existing related object also when creating the base object. Currently this is not possible, all related objects are always created as new even when they exist in the database and their `pk` value is submitted to the serializer. This pull request fixes that. Now all related objects are either updated/added _or_ created for both `create` and `update` actions. 