### PR TITLE
Don't delete related M2M objects when removing the relation

### DIFF
--- a/drf_writable_nested/mixins.py
+++ b/drf_writable_nested/mixins.py
@@ -232,7 +232,7 @@ class NestedUpdateMixin(BaseNestedModelSerializer):
             if related_field.one_to_one:
                 related_data = [related_data]
 
-            # M2M relation can be as direct as reverse. For direct relation we
+            # M2M relation can be as direct or as reverse. For direct relation we
             # should use reverse relation name
             if related_field.many_to_many and \
                     not isinstance(related_field, ForeignObjectRel):
@@ -257,12 +257,11 @@ class NestedUpdateMixin(BaseNestedModelSerializer):
                 )
 
                 if related_field.many_to_many:
-                    # Remove relations from m2m table before deleting
-                    # It is necessary for correct m2m_changes signal handling
+                    # Remove relations from m2m table
                     m2m_manager = getattr(instance, field_name)
                     m2m_manager.remove(*pks_to_delete)
-
-                model_class.objects.filter(pk__in=pks_to_delete).delete()
+                else:
+                    model_class.objects.filter(pk__in=pks_to_delete).delete()
 
             except ProtectedError as e:
                 instances = e.args[1]

--- a/tests/test_writable_nested_model_serializer.py
+++ b/tests/test_writable_nested_model_serializer.py
@@ -169,10 +169,11 @@ class WritableNestedModelSerializerTest(TestCase):
         # Check instances count
         self.assertEqual(models.User.objects.count(), 1)
         self.assertEqual(models.Profile.objects.count(), 1)
-        self.assertEqual(models.Site.objects.count(), 1)
         self.assertEqual(models.Avatar.objects.count(), 3)
         # Access key shouldn't be removed because it is FK
         self.assertEqual(models.AccessKey.objects.count(), 1)
+        # Sites shouldn't be deleted either as it is M2M
+        self.assertEqual(models.Site.objects.count(), 3)
 
     def test_update_with_empty_reverse_one_to_one(self):
         serializer = serializers.UserSerializer(data=self.get_initial_data())


### PR DESCRIPTION
Deleting M2M related objects when the relation is removed is counterintuitive to the M2M concept. E g if you have Users that belongs to Groups, it is a strange use case that you delete the whole Group for everyone when removing one User from it.