### PR TITLE
Fix problem with raising protected error in deleteion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.1
+* Fix problem with raising Protected Error in deletion (@kseniyashaydurova)
+
 ## 0.2.0
 * Add support for custom primary key field #10 (@tjwalch)
 * Add possibility to pass through argument from serializer.save method (@tjwalch)

--- a/drf_writable_nested/mixins.py
+++ b/drf_writable_nested/mixins.py
@@ -267,4 +267,4 @@ class NestedUpdateMixin(BaseNestedModelSerializer):
             except ProtectedError as e:
                 instances = e.args[1]
                 self.fail('cannot_delete_protected', instances=", ".join([
-                    instance for instance in instances]))
+                    str(instance) for instance in instances]))

--- a/tests/models.py
+++ b/tests/models.py
@@ -9,6 +9,7 @@ class Site(models.Model):
 
 class User(models.Model):
     username = models.CharField(max_length=100)
+    user_avatar = models.ForeignKey('Avatar', null=True)
 
 
 class AccessKey(models.Model):
@@ -21,9 +22,26 @@ class Profile(models.Model):
     access_key = models.ForeignKey(AccessKey, null=True)
 
 
+class AvatarQuerySet(models.QuerySet):
+    def delete(self):
+        for obj in self:
+            if User.objects.filter(user_avatar=obj).exists():
+                raise models.deletion.ProtectedError(
+                    'You are trying to delete avatar which is used in as user'
+                    'avatar',
+                    protected_objects=[obj]
+                )
+            obj.delete()
+
+
 class Avatar(models.Model):
     image = models.CharField(max_length=100)
-    profile = models.ForeignKey(Profile, related_name='avatars')
+    profile = models.ForeignKey(
+        Profile,
+        related_name='avatars',
+    )
+
+    objects = AvatarQuerySet.as_manager()
 
 
 class Tag(models.Model):

--- a/tests/test_writable_nested_model_serializer.py
+++ b/tests/test_writable_nested_model_serializer.py
@@ -1,3 +1,4 @@
+from rest_framework.exceptions import ValidationError
 from django.test import TestCase
 
 from . import (
@@ -173,6 +174,38 @@ class WritableNestedModelSerializerTest(TestCase):
         self.assertEqual(models.Avatar.objects.count(), 3)
         # Access key shouldn't be removed because it is FK
         self.assertEqual(models.AccessKey.objects.count(), 1)
+
+    def test_update_raise_protected_error(self):
+        serializer = serializers.UserSerializer(data=self.get_initial_data())
+        serializer.is_valid(raise_exception=True)
+        user = serializer.save()
+
+        user.user_avatar = user.profile.avatars.first()
+        user.save()
+
+        serializer = serializers.ProfileSerializer(
+            instance=user.profile,
+            data={
+                'access_key': None,
+                'sites': [],
+                'avatars': [
+                    {
+                        'pk': user.profile.avatars.last().id,
+                        'image': 'old-image-1.png',
+                    },
+                    {
+                        'image': 'new-image-1.png',
+                    },
+                ],
+            }
+        )
+
+        serializer.is_valid(raise_exception=True)
+        with self.assertRaises(ValidationError):
+            serializer.save()
+
+        # Check that protected avatar haven't been deleted
+        self.assertEqual(models.Avatar.objects.count(), 3)
 
     def test_update_with_empty_reverse_one_to_one(self):
         serializer = serializers.UserSerializer(data=self.get_initial_data())


### PR DESCRIPTION
There was a problem in raising protected error, `join` method failed
because it tried to join instance instead of its str representation (mixins.py line 270)

<code>
self.fail('cannot_delete_protected', instances=", ".join([(instance) for instance in instances]))
</code>

Fixed problem, changed Avatar and User model to provide error situation,
added its test.