### PR TITLE
Fix problem for update models with UUID id fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.1
+* Fix problem for updating models with UUID primary key field (@kseniyashaydurova)
+
 ## 0.2.0
 * Add support for custom primary key field #10 (@tjwalch)
 * Add possibility to pass through argument from serializer.save method (@tjwalch)

--- a/drf_writable_nested/mixins.py
+++ b/drf_writable_nested/mixins.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import uuid
 from collections import OrderedDict, defaultdict
 
 from django.contrib.contenttypes.fields import GenericRelation
@@ -82,12 +83,11 @@ class BaseNestedModelSerializer(serializers.ModelSerializer):
             pk = self._get_related_pk(d, model_class)
             if pk:
                 pk_list.append(pk)
-        instances = {
-            related_instance.pk: related_instance
-            for related_instance in model_class.objects.filter(
-                pk__in=pk_list,
-            )
-        }
+        instances = {}
+        for related_instance in model_class.objects.filter(pk__in=pk_list,):
+            if isinstance(related_instance.pk, uuid.UUID):
+                instances[str(related_instance.pk)] = related_instance
+            instances[related_instance.pk] = related_instance
         return instances
 
     def _get_related_pk(self, data, model_class):

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,3 +1,4 @@
+import uuid
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
@@ -54,3 +55,13 @@ class CustomPK(models.Model):
         on_delete=models.CASCADE,
         related_name='custompks',
     )
+
+
+class Message(models.Model):
+    id = models.UUIDField(
+        primary_key=True,
+        default=uuid.uuid4,
+        editable=False
+    )
+    profile = models.ForeignKey(Profile, related_name='messages')
+    message = models.CharField(max_length=100)

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -12,6 +12,13 @@ class AvatarSerializer(serializers.ModelSerializer):
         fields = ('pk', 'image',)
 
 
+class MessageSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = models.Message
+        fields = ('pk', 'message',)
+
+
 class SiteSerializer(serializers.ModelSerializer):
     url = serializers.CharField()
 
@@ -37,9 +44,12 @@ class ProfileSerializer(WritableNestedModelSerializer):
     # Direct FK relation
     access_key = AccessKeySerializer(allow_null=True)
 
+    # Reverse FK relation with UUID
+    messages = MessageSerializer(many=True)
+
     class Meta:
         model = models.Profile
-        fields = ('pk', 'sites', 'avatars', 'access_key',)
+        fields = ('pk', 'sites', 'avatars', 'access_key', 'messages',)
 
 
 class UserSerializer(WritableNestedModelSerializer):

--- a/tests/test_writable_nested_model_serializer.py
+++ b/tests/test_writable_nested_model_serializer.py
@@ -240,6 +240,7 @@ class WritableNestedModelSerializerTest(TestCase):
                         'image': 'new-image-1.png',
                     },
                 ],
+                'messages': [],
             }
         )
 


### PR DESCRIPTION
There was a problem for updating models with UUID primary key fields:
instead of updating old instance it created new one and deleted old.

Fixed `prefetch_related_instances` method to use str for uuid primary
keys and its UUID object in instances dict, added new Message model
with its serializer to provide error situation and adjusted `test_update`
to check it.

In real usage UUID pk fields comes in deserialized request query params as strings thats why the problem appears.