### PR TITLE
Support m2m fields that do not have `related_name` specified

### DIFF
--- a/drf_writable_nested/mixins.py
+++ b/drf_writable_nested/mixins.py
@@ -58,7 +58,16 @@ class BaseNestedModelSerializer(serializers.ModelSerializer):
     def _get_related_field(self, field):
         model_class = self.Meta.model
 
-        related_field = model_class._meta.get_field(field.source)
+        try:
+            related_field = model_class._meta.get_field(field.source)
+        except FieldDoesNotExist:
+            # If `related_name` is not set, field name does not include `_set` -> remove it and check again
+            default_postfix = '_set'
+            if field.source.endswith(default_postfix):
+                related_field = model_class._meta.get_field(field.source[:-len(default_postfix)])
+            else:
+                raise
+
         if isinstance(related_field, ForeignObjectRel):
             return related_field.field, False
         return related_field, True

--- a/tests/models.py
+++ b/tests/models.py
@@ -68,5 +68,5 @@ class Message(models.Model):
         default=uuid.uuid4,
         editable=False
     )
-    profile = models.ForeignKey(Profile, related_name='messages')
+    profile = models.ForeignKey(Profile)
     message = models.CharField(max_length=100)

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -45,11 +45,11 @@ class ProfileSerializer(WritableNestedModelSerializer):
     access_key = AccessKeySerializer(allow_null=True)
 
     # Reverse FK relation with UUID
-    messages = MessageSerializer(many=True)
+    message_set = MessageSerializer(many=True)
 
     class Meta:
         model = models.Profile
-        fields = ('pk', 'sites', 'avatars', 'access_key', 'messages',)
+        fields = ('pk', 'sites', 'avatars', 'access_key', 'message_set',)
 
 
 class UserSerializer(WritableNestedModelSerializer):

--- a/tests/test_writable_nested_model_serializer.py
+++ b/tests/test_writable_nested_model_serializer.py
@@ -32,7 +32,7 @@ class WritableNestedModelSerializerTest(TestCase):
                         'image': 'image-2.png',
                     },
                 ],
-                'messages': [
+                'message_set': [
                     {
                         'message': 'Message 1'
                     },
@@ -129,8 +129,8 @@ class WritableNestedModelSerializerTest(TestCase):
         user_pk = user.pk
         profile_pk = user.profile.pk
 
-        message_to_update_str_pk = str(user.profile.messages.first().pk)
-        message_to_update_pk = user.profile.messages.last().pk
+        message_to_update_str_pk = str(user.profile.message_set.first().pk)
+        message_to_update_pk = user.profile.message_set.last().pk
         serializer = serializers.UserSerializer(
             instance=user,
             data={
@@ -156,7 +156,7 @@ class WritableNestedModelSerializerTest(TestCase):
                             'image': 'new-image-2.png',
                         },
                     ],
-                    'messages': [
+                    'message_set': [
                         {
                             'pk': message_to_update_str_pk,
                             'message': 'Old message 1'
@@ -195,18 +195,18 @@ class WritableNestedModelSerializerTest(TestCase):
             {'old-image-1.png', 'new-image-1.png', 'new-image-2.png'}
         )
         self.assertSetEqual(
-            set(profile.messages.values_list('message', flat=True)),
+            set(profile.message_set.values_list('message', flat=True)),
             {'Old message 1', 'Old message 2', 'New message 1'}
         )
         # Check that message which supposed to be updated still in profile
-        # messages (new message wasn't created instead of update)
+        # message_set (new message wasn't created instead of update)
         self.assertIn(
             message_to_update_pk,
-            profile.messages.values_list('id', flat=True)
+            profile.message_set.values_list('id', flat=True)
         )
         self.assertIn(
             uuid.UUID(message_to_update_str_pk),
-            profile.messages.values_list('id', flat=True)
+            profile.message_set.values_list('id', flat=True)
         )
 
         # Check instances count
@@ -241,7 +241,7 @@ class WritableNestedModelSerializerTest(TestCase):
                         'image': 'new-image-1.png',
                     },
                 ],
-                'messages': [],
+                'message_set': [],
             }
         )
 


### PR DESCRIPTION
This library currently assumes that the `related_name` field is explicitly set in the foreign key definition. This change gives support to something like this:

```
profile = models.ForeignKey(Profile)  # No `related_name` set
```