### PR TITLE
Fix multipart form data request

### DIFF
--- a/drf_writable_nested/mixins.py
+++ b/drf_writable_nested/mixins.py
@@ -118,7 +118,9 @@ class BaseNestedModelSerializer(serializers.ModelSerializer):
         # many-to-one, many-to-many, reversed one-to-one
         for field_name, (related_field, field, field_source) in \
                 reverse_relations.items():
-            related_data = self.initial_data[field_name]
+            related_data = self.initial_data.get(field_name)
+            if not related_data:
+                continue
             # Expand to array of one item for one-to-one for uniformity
             if related_field.one_to_one:
                 if related_data is None:

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -96,7 +96,7 @@ class TaggedItemSerializer(WritableNestedModelSerializer):
 
 
 class TeamSerializer(WritableNestedModelSerializer):
-    members = UserSerializer(many=True)
+    members = UserSerializer(many=True, required=False)
 
     class Meta:
         model = models.Team

--- a/tests/test_writable_nested_model_serializer.py
+++ b/tests/test_writable_nested_model_serializer.py
@@ -1,6 +1,7 @@
 import uuid
 from rest_framework.exceptions import ValidationError
 from django.test import TestCase
+from django.http.request import QueryDict
 
 from . import (
     models,
@@ -715,3 +716,16 @@ class WritableNestedModelSerializerTest(TestCase):
         self.assertEqual(models.AccessKey.objects.count(), 1)
         # Sites shouldn't be deleted either as it is M2M
         self.assertEqual(models.Site.objects.count(), 3)
+
+    def test_create_with_html_input_data(self):
+        """Serializer should not fail if request type is multipart
+        """
+        # DRF sets data to `QueryDuct` when request type is `multipart`
+        data = QueryDict('name=team')
+        serializer = serializers.TeamSerializer(
+            data=data
+        )
+        serializer.is_valid(raise_exception=True)
+        team = serializer.save()
+
+        self.assertTrue(models.Team.objects.filter(id=team.id).exists())


### PR DESCRIPTION
Add check that field exists in `initial_data`

There are may be different cases when some field exists in `validated_data` and does not exists in `initial_data`.

For example, developer may implement `Serializer.validate` method and provide some default values for fields, that were not sent in request.

Also DRF may have different return values for `ListSerializer.get_value` method, which returns `class empty` in case of JSON format, or `[]` for `multipart` request
