### PR TITLE
fixed MultiValueDictKeyError for nested_updates on reverse-relations

### DIFF
--- a/drf_writable_nested/mixins.py
+++ b/drf_writable_nested/mixins.py
@@ -121,7 +121,7 @@ class BaseNestedModelSerializer(serializers.ModelSerializer):
             # Skip processing for empty data or not-specified field.
             # The field can be defined in validated_data but isn't defined
             # in initial_data (for example, if multipart form data used)
-            related_data = self.initial_data.get(field_name, None)
+            related_data = self.get_initial().get(field_name, None)
             if related_data is None:
                 continue
 
@@ -171,7 +171,7 @@ class BaseNestedModelSerializer(serializers.ModelSerializer):
     def update_or_create_direct_relations(self, attrs, relations):
         for field_name, (field, field_source) in relations.items():
             obj = None
-            data = self.initial_data[field_name]
+            data = self.get_initial()[field_name]
             model_class = field.Meta.model
             pk = self._get_related_pk(data, model_class)
             if pk:
@@ -262,7 +262,7 @@ class NestedUpdateMixin(BaseNestedModelSerializer):
                 reverse_relations.items():
             model_class = field.Meta.model
 
-            related_data = self.initial_data[field_name]
+            related_data = self.get_initial()[field_name]
             # Expand to array of one item for one-to-one for uniformity
             if related_field.one_to_one:
                 related_data = [related_data]

--- a/tests/models.py
+++ b/tests/models.py
@@ -86,3 +86,12 @@ class AnotherAvatar(models.Model):
     image = models.CharField(max_length=100)
     profile = models.ForeignKey(
         AnotherProfile, on_delete=models.CASCADE, related_name='avatars',)
+
+
+class Page(models.Model):
+    title = models.CharField(max_length=80)
+
+
+class Document(models.Model):
+    page = models.ForeignKey(Page, on_delete=models.CASCADE)
+    source = models.FileField()

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -160,3 +160,17 @@ class AnotherUserSerializer(WritableNestedModelSerializer):
     class Meta:
         model = models.User
         fields = ('pk', 'another_profile', 'username',)
+
+
+class PageSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.Page
+        fields = ('pk', 'title')
+
+
+class DocumentSerializer(WritableNestedModelSerializer):
+    page = PageSerializer()
+
+    class Meta:
+        model = models.Document
+        fields = ('pk', 'page', 'source')

--- a/tests/test_writable_nested_model_serializer.py
+++ b/tests/test_writable_nested_model_serializer.py
@@ -3,6 +3,8 @@ from rest_framework.exceptions import ValidationError
 from django.test import TestCase
 from django.http.request import QueryDict
 
+from .utils import get_sample_file
+
 from . import (
     models,
     serializers,
@@ -836,3 +838,20 @@ class WritableNestedModelSerializerTest(TestCase):
 
         self.assertTrue(models.Team.objects.filter(id=team.id).exists())
         self.assertEqual(team.name, 'team')
+
+    def test_create_with_file(self):
+        data = {
+            'page.title': 'some page',
+            'source': get_sample_file(name='sample name')
+        }
+        qdict = QueryDict('', mutable=True)
+        qdict.update(data)
+
+        serializer = serializers.DocumentSerializer(
+            data=qdict
+        )
+        serializer.is_valid(raise_exception=True)
+        doc = serializer.save()
+
+        self.assertTrue(models.Document.objects.filter(pk=doc.pk).exists())
+        self.assertEqual(doc.page.title, 'some page')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,10 @@
+import tempfile
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+
+def get_sample_file(name, content=b'*'):
+        with tempfile.NamedTemporaryFile() as tf:
+            tf.file.write(content)
+            tf.file.seek(0)
+            return SimpleUploadedFile(name, tf.file.read())


### PR DESCRIPTION
use self.get_initial() instead of self.initial_data()