### PR TITLE
Add support for Python 3.7 and Django 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 language: python
 
-python:
-    - "2.7"
-    - "3.5"
-    - "3.6"
-
 sudo: false
 
 env:
@@ -12,9 +7,18 @@ env:
     - DJANGO=1.10
     - DJANGO=1.11
     - DJANGO=2.0
+    - DJANGO=2.1
 
 matrix:
     fast_finish: true
+    include:
+        - python: 2.7
+        - python: 3.4
+        - python: 3.5
+        - python: 3.6
+        - python: 3.7
+          dist: xenial
+          sudo: true
 
 install:
     - pip install tox tox-travis

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ The following relations are supported:
 Requirements
 ============
 
-- Python (2.7, 3.5, 3.6)
-- Django (1.9, 1.10, 1.11, 2.0)
+- Python (2.7, 3.5, 3.6, 3.7)
+- Django (1.9, 1.10, 1.11, 2.0, 2.1)
 - djangorestframework (3.5+)
 
 Installation

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
@@ -53,6 +54,8 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Internet :: WWW/HTTP',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ addopts=--tb=short
 [tox]
 envlist =
     py{27,35}-dj{19}-drf{35,36}
-    py{27,35,36}-dj{110,111}-drf{35,36,37}
-    py{36}-dj{20}-drf{37}
+    py{27,35,36}-dj{110,111}-drf{35,36,37,38,39}
+    py{36,37}-dj{20,21}-drf{37,38,39}
 
 [travis:env]
 DJANGO =
@@ -13,6 +13,7 @@ DJANGO =
     1.10: dj110
     1.11: dj111
     2.0: dj20
+    2.1: dj21
 
 [testenv]
 commands = ./py.test --cov drf_writable_nested
@@ -24,6 +25,7 @@ deps =
     dj110: Django>=1.10,<1.11
     dj111: Django>=1.11a1,<2.0
     dj20: Django>=2.0,<2.1
+    dj21: Django>=2.1,<2.2
     drf35: djangorestframework>=3.5,<3.6
     drf36: djangorestframework>=3.6.0,<3.7
     drf37: djangorestframework>=3.7.0,<3.8


### PR DESCRIPTION
Python 3.7 Travis support is based upon https://github.com/travis-ci/travis-ci/issues/9815#issue-336465122

Should we also remove:

```
'Programming Language :: Python :: 3.3',
'Programming Language :: Python :: 3.4',
```

As it doesn't seem like we are actually testing those versions any more?