### PR TITLE
Support Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: python
 
+dist: xenial
+
 python:
     - "2.7"
     - "3.5"
     - "3.6"
+    - "3.7"
 
 sudo: false
 

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Internet :: WWW/HTTP',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ addopts=--tb=short
 [tox]
 envlist =
     py{27,35}-dj{19}-drf{35,36}
-    py{27,35,36}-dj{110,111}-drf{35,36,37}
-    py{35,36}-dj{20,21}-drf{37,38,39}
+    py{27,35,36,37}-dj{110,111}-drf{35,36,37}
+    py{35,36,37}-dj{20,21}-drf{37,38,39}
 
 [travis:env]
 DJANGO =


### PR DESCRIPTION
[`dist: xenial` is needed for Python 3.7+ on Travis CI](https://github.com/travis-ci/travis-ci/issues/9815).

Fixes #62 