### PR TITLE
Support Django 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - DJANGO=1.11
     - DJANGO=2.0
     - DJANGO=2.1
+    - DJANGO=2.2
 
 matrix:
     fast_finish: true

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Requirements
 ============
 
 - Python (2.7, 3.5, 3.6, 3.7)
-- Django (1.9, 1.10, 1.11, 2.0, 2.1)
+- Django (1.9, 1.10, 1.11, 2.0, 2.1, 2.2)
 - djangorestframework (3.5+)
 
 Installation

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
+        'Framework :: Django :: 2.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ addopts=--tb=short
 envlist =
     py{27,35}-dj{19}-drf{35,36}
     py{27,35,36,37}-dj{110,111}-drf{35,36,37}
-    py{35,36,37}-dj{20,21}-drf{37,38,39}
+    py{35,36,37}-dj{20,21,22}-drf{37,38,39}
 
 [travis:env]
 DJANGO =
@@ -14,6 +14,7 @@ DJANGO =
     1.11: dj111
     2.0: dj20
     2.1: dj21
+    2.2: dj22
 
 [testenv]
 commands = ./py.test --cov drf_writable_nested
@@ -26,6 +27,7 @@ deps =
     dj111: Django>=1.11a1,<2.0
     dj20: Django>=2.0,<2.1
     dj21: Django>=2.1,<2.2
+    dj22: Django>=2.2,<2.3
     drf35: djangorestframework>=3.5,<3.6
     drf36: djangorestframework>=3.6.0,<3.7
     drf37: djangorestframework>=3.7.0,<3.8


### PR DESCRIPTION
@ruscoder Looks like an actual incompatibility with Django 2.2.

*Maybe* related to: https://docs.djangoproject.com/en/2.2/releases/2.2/#permissions-for-proxy-models?