### PR TITLE
FieldDoesNotExist import bug fix (Django 3.1)

### DIFF
--- a/drf_writable_nested/mixins.py
+++ b/drf_writable_nested/mixins.py
@@ -3,7 +3,8 @@ from collections import OrderedDict, defaultdict
 
 from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import ProtectedError, FieldDoesNotExist
+from django.core.exceptions import FieldDoesNotExist
+from django.db.models import ProtectedError
 from django.db.models.fields.related import ForeignObjectRel
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers

--- a/tox.ini
+++ b/tox.ini
@@ -6,12 +6,14 @@ DJANGO_SETTINGS_MODULE = tests.settings
 envlist =
     py{35,36,37,38}-dj{22}-drf{38,39,310,311}
     py{36,37,38}-dj{30}-drf{310,311}
+    py{36,37,38}-dj{31}-drf{311}
 skip_missing_interpreters = true
 
 [travis:env]
 DJANGO =
     2.2: dj22
     3.0: dj30
+    3.1: dj31
 
 [testenv]
 commands = ./py.test --cov drf_writable_nested
@@ -21,6 +23,7 @@ setenv =
 deps =
     dj22: Django>=2.2,<2.3
     dj30: Django>=3.0,<3.1
+    dj31: Django>=3.1,<3.2
     drf38: djangorestframework>=3.8.0,<3.9
     drf39: djangorestframework>=3.9.0,<3.10
     drf310: djangorestframework>=3.10.0,<3.11


### PR DESCRIPTION
Fixed import error in **Django 3.1**
The import error also occurs in **Django 3.1 and DRF 3.10**, so the **Django 3.1 related parts** in the tox setting are separated.

```
py{36,37,38}-dj{31}-drf{311}
```

https://docs.djangoproject.com/en/3.1/releases/3.1/#id1
The compatibility import of **django.core.exceptions.FieldDoesNotExist** in **django.db.models.fields** is removed.