### PR TITLE
UniqueFieldsMixin validation optional for partial update

### DIFF
--- a/drf_writable_nested/mixins.py
+++ b/drf_writable_nested/mixins.py
@@ -400,6 +400,8 @@ class UniqueFieldsMixin(serializers.ModelSerializer):
 
     def _validate_unique_fields(self, validated_data):
         for field_name in self._unique_fields:
+            if self.partial and field_name not in validated_data:
+                continue
             unique_validator = UniqueValidator(self.Meta.model.objects.all())
             try:
                 # `set_context` removed on DRF >= 3.11, pass in via __call__ instead

--- a/tests/test_unique_fields_mixin.py
+++ b/tests/test_unique_fields_mixin.py
@@ -77,3 +77,4 @@ class UniqueFieldsMixinTestCase(TestCase):
             partial=True
         )
         self.assertTrue(serializer.is_valid())
+        serializer.save()

--- a/tests/test_unique_fields_mixin.py
+++ b/tests/test_unique_fields_mixin.py
@@ -68,3 +68,12 @@ class UniqueFieldsMixinTestCase(TestCase):
             ctx.exception.detail,
             {'child': {'field': ['This field must be unique.']}}
         )
+
+    def test_unique_field_not_required_for_partial_updates(self):
+        child = models.UFMChild.objects.create(field='value')
+        serializer = serializers.UFMChildSerializer(
+            instance=child,
+            data={},
+            partial=True
+        )
+        self.assertTrue(serializer.is_valid())


### PR DESCRIPTION
_validate_unique_fields now accounts for partial updates and does not attempt checks on fields if they've not been provided.