### PR TITLE
Test Django 3.1 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,15 @@ matrix:
 
       - { python: "3.6", env: DJANGO=2.2 }
       - { python: "3.6", env: DJANGO=3.0 }
+      - { python: "3.6", env: DJANGO=3.1 }
 
       - { python: "3.7", env: DJANGO=2.2 }
       - { python: "3.7", env: DJANGO=3.0 }
+      - { python: "3.7", env: DJANGO=3.1 }
 
       - { python: "3.8", env: DJANGO=2.2 }
       - { python: "3.8", env: DJANGO=3.0 }
+      - { python: "3.8", env: DJANGO=3.1 }
 
 install:
     - pip install tox tox-travis

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Requirements
 ============
 
 - Python (3.5, 3.6, 3.7, 3.8)
-- Django (2.2, 3.0)
+- Django (2.2, 3.0, 3.1)
 - djangorestframework (3.8+)
 
 Installation

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
+        'Framework :: Django :: 3.1',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',


### PR DESCRIPTION
Support for Django 3.1 was added in #114, but CI testing was not added. This PR adds Django 3.1 testing to CI.