### PR TITLE
Upgrades to `pytest-django==4.0.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # PyTest for running the tests.
 pytest==5.4.1
-pytest-django==3.9.0
+pytest-django==4.0.0
 pytest-cov==2.8.1


### PR DESCRIPTION
eliminates `six` dependency by upgrading pytest-django to 4.0 to fix #132 