### PR TITLE
Add support for initializing serializer with many=True

### DIFF
--- a/drf_writable_nested/mixins.py
+++ b/drf_writable_nested/mixins.py
@@ -208,7 +208,8 @@ class BaseNestedModelSerializer(serializers.ModelSerializer):
                 m2m_manager = getattr(instance, field_source)
                 m2m_manager.add(*new_related_instances)
 
-    def update_or_create_direct_relations(self, attrs, relations, inital_data):
+    def update_or_create_direct_relations(self, attrs, relations, inital_data=None):
+        inital_data = inital_data or self.get_initial()
         for field_name, (field, field_source) in relations.items():
             obj = None
             data = inital_data[field_name]


### PR DESCRIPTION
This adds support for initializing serializer with `many=True`. Only with action create from view function. Needs to be reviewed.
Example usage:

**serializers.py**
```
from rest_framework import serializers
from drf_writable_nested import WritableNestedModelSerializer
from .models import Person, MyModel

class PersonSerializer(serializers.ModelSerializer):
    class Meta:
        model = Person
        fields = '__all__'

class MyModelSerializer(WritableNestedModelSerializer):
    person = PersonSerializer()
    class Meta:
        model = MyModel
        fields = '__all__'
```

**views.py**
```
from rest_framework import viewsets
from .serializers import MyModelSerializer
from .models import MyModel

class MyModelViewset(viewsets.ModelViewSet):
    serializer_class = MyModelSerializer
    queryset = MyModel.objects.all()

    def get_serializer(self, *args, **kwargs):
        if self.action == 'create':
            kwargs['many'] = True
        return super().get_serializer(*args, **kwargs)
```