### PR TITLE
Add support for many=True on create

### DIFF
--- a/drf_writable_nested/mixins.py
+++ b/drf_writable_nested/mixins.py
@@ -13,7 +13,36 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.validators import UniqueValidator
 
 
+class BaseNestedListSerializer(serializers.ListSerializer):
+    def create(self, validated_data):
+        instances = []
+        for attrs in self.get_initial():
+            self.child.initial_data = attrs
+            instances.append(
+                self.child.create(
+                    validated_data=self.child.to_internal_value(attrs)
+                )
+            )
+        return instances
+
+    def update(self, instance, validated_data):
+        raise NotImplementedError(
+            "Update not supported with many=True, only create."
+        )
+
+    def save(self, **kwargs):
+        self.child._save_kwargs = defaultdict(dict, kwargs)
+
+        super(BaseNestedListSerializer, self).save(**kwargs)
+
 class BaseNestedModelSerializer(serializers.ModelSerializer):
+    @classmethod
+    def many_init(cls, *args, **kwargs):
+        # Allow overriding of list_serializer_class, else use BaseNestedListSerializer
+        if not getattr(cls.Meta, 'list_serializer_class', None):
+            cls.Meta.list_serializer_class = BaseNestedListSerializer
+        return super(BaseNestedModelSerializer, cls).many_init(*args, **kwargs)
+
     def _extract_relations(self, validated_data):
         reverse_relations = OrderedDict()
         relations = OrderedDict()

--- a/drf_writable_nested/mixins.py
+++ b/drf_writable_nested/mixins.py
@@ -38,7 +38,7 @@ class BaseNestedListSerializer(serializers.ListSerializer):
 class BaseNestedModelSerializer(serializers.ModelSerializer):
     @classmethod
     def many_init(cls, *args, **kwargs):
-        # Allow overriding of list_serializer_class, else use BaseNestedListSerializer
+        # Allow overriding of list_serializer_class, default to BaseNestedListSerializer
         if not getattr(cls.Meta, 'list_serializer_class', None):
             cls.Meta.list_serializer_class = BaseNestedListSerializer
         return super(BaseNestedModelSerializer, cls).many_init(*args, **kwargs)


### PR DESCRIPTION
This adds support for initializing serializer with `many=True`. Only with action create from view function. Needs to be reviewed.
Example usage (Same as current usage, except if you want to use many=True, you have to instantiatethe serializer with that kwarg):

**serializers.py**
```
from drf_writable_nested import WritableNestedModelSerializer

class MyModelSerializer(WritableNestedModelSerializer):
    owner = PersonSerializer() # Some nested serializer
    toys = ToySerializer(many=True) # Another nested serializer

    class Meta:
        model = MyModel
        fields = '__all__'
```

**views.py**
```
from rest_framework import viewsets
from .serializers import MyModelSerializer
from .models import MyModel

class MyModelViewset(viewsets.ModelViewSet):
    serializer_class = MyModelSerializer
    queryset = MyModel.objects.all()

    def get_serializer(self, *args, **kwargs):
        if self.action == 'create':
            kwargs['many'] = True
        return super().get_serializer(*args, **kwargs)
```

Or to allow for sending one or many:
```
from rest_framework import viewsets
from .serializers import MyModelSerializer
from .models import MyModel

class MyModelViewset(viewsets.ModelViewSet):
    serializer_class = MyModelSerializer
    queryset = MyModel.objects.all()

    def get_serializer(self, *args, **kwargs):
        if self.action == 'create' and isinstance(kwargs['data'], list):
            kwargs['many'] = True
        return super().get_serializer(*args, **kwargs)

```