### PR TITLE
Remove redundant refresh following the update procedure

### DIFF
--- a/drf_writable_nested/mixins.py
+++ b/drf_writable_nested/mixins.py
@@ -288,7 +288,6 @@ class NestedUpdateMixin(BaseNestedModelSerializer):
         )
         self.update_or_create_reverse_relations(instance, reverse_relations)
         self.delete_reverse_relations_if_need(instance, reverse_relations)
-        instance.refresh_from_db()
         return instance
 
     def perform_nested_delete(self, pks_to_delete, model_class, instance, related_field, field_source):


### PR DESCRIPTION
We use a read replica database in our deployment. As such, there is some nonzero replication lag between the write DB and the read replica DB. Because `NestedUpdateMixin.update()` performs `instance.refresh_from_db()` immediately following the write operations, we sometimes get stale data from the refresh.

Stepping through the code, I found that (in all our usages, anyway) the refresh was redundant. The nested objects are all updated independently and then reattached to parent objects as [part of vanilla DRF](https://github.com/encode/django-rest-framework/blob/0323d6f8955f987771269506ca5da461e2e7a248/rest_framework/serializers.py#L981), making the refresh operation superfluous.

One possible risk I may have not accounted for is many-to-many relations. I don't think our specific use case encounters those.

If this solution is unacceptable, please let me know and I'll rework it into an instance attribute or method kwarg that will either direct drf-writable-nested which database to use in making its read immediately following the write or whether to electively skip the refresh entirely. Currently, our solution is to monkey patch, which we'd like to avoid. Also, if it would be better to go through a formal Issue process first, let me know. I'm very grateful for your work and contribution here. It has saved me a lot of time and heartache.