### PR TITLE
Add support for Django 4.0 and DRF 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Requirements
 ============
 
 - Python (3.5, 3.6, 3.7, 3.8, 3.9, 3.10)
-- Django (2.2, 3.0, 3.1, 3.2)
+- Django (2.2, 3.0, 3.1, 3.2, 4.0)
 - djangorestframework (3.8+)
 
 Installation

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',
+        'Framework :: Django :: 4.0',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,8 @@ envlist =
     py35-dj{22}-drf{38,39,310,311}-pytest
     py{36,37,38}-dj{22}-drf{38,39,310,311}-{pytest,mypy}
     py{36,37,38}-dj{30}-drf{310,311}-{pytest,mypy}
-    py{36,37,38,39,310}-dj{31,32}-drf{311,312}-{pytest,mypy}
+    py{36,37,38,39,310}-dj{31,32}-drf{311,312,313}-{pytest,mypy}
+    py{38,39,310}-dj{40}-drf{313}-{pytest,mypy}
 skip_missing_interpreters = true
 
 [travis:env]
@@ -26,11 +27,13 @@ deps =
     dj30: Django>=3.0,<3.1
     dj31: Django>=3.1,<3.2
     dj32: Django>=3.2a1,<4.0
+    dj40: Django>=4.0,<4.1
     drf38: djangorestframework>=3.8.0,<3.9
     drf39: djangorestframework>=3.9.0,<3.10
     drf310: djangorestframework>=3.10.0,<3.11
     drf311: djangorestframework>=3.11,<3.12
-    drf312: djangorestframework>=3.12,<4.0
+    drf312: djangorestframework>=3.12,<3.13
+    drf313: djangorestframework>=3.13,<3.14
     pytest: -rrequirements.txt
     mypy: -rexample/requirements.txt
 commands=


### PR DESCRIPTION
Unfortunately there is no longer any CI running to verify this (#161).

When merging, please squash the commits using the GitHub UI.