### PR TITLE
Make serializer classes generic (for mypy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+* Make serializer classes generic (@noamkush)
+
 ## 0.7.2
 * Add support for Django 5.1, 5.2 and Python 3.13 (@browniebroke)
 * Drop support for end-of-life Python 3.8 (@browniebroke)

--- a/drf_writable_nested/mixins.py
+++ b/drf_writable_nested/mixins.py
@@ -1,19 +1,21 @@
 # -*- coding: utf-8 -*-
 from collections import OrderedDict, defaultdict
-from typing import List, Tuple
+from typing import List, Tuple, TypeVar
 
 from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldDoesNotExist
-from django.db.models import ProtectedError, SET_NULL, SET_DEFAULT
+from django.db.models import ProtectedError, SET_NULL, SET_DEFAULT, Model
 from django.db.models.fields.related import ForeignObjectRel, ManyToManyRel
 from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from rest_framework.validators import UniqueValidator
 
+_MT = TypeVar("_MT", bound=Model)
 
-class BaseNestedModelSerializer(serializers.ModelSerializer):
+
+class BaseNestedModelSerializer(serializers.ModelSerializer[_MT]):
     def _extract_relations(self, validated_data):
         reverse_relations = OrderedDict()
         relations = OrderedDict()
@@ -241,7 +243,7 @@ class BaseNestedModelSerializer(serializers.ModelSerializer):
         return save_kwargs
 
 
-class NestedCreateMixin(BaseNestedModelSerializer):
+class NestedCreateMixin(BaseNestedModelSerializer[_MT]):
     """
     Adds nested create feature
     """
@@ -262,7 +264,7 @@ class NestedCreateMixin(BaseNestedModelSerializer):
         return instance
 
 
-class NestedUpdateMixin(BaseNestedModelSerializer):
+class NestedUpdateMixin(BaseNestedModelSerializer[_MT]):
     """
     Adds update nested feature
     """
@@ -362,7 +364,7 @@ class NestedUpdateMixin(BaseNestedModelSerializer):
                     str(instance) for instance in instances]))
 
 
-class UniqueFieldsMixin(serializers.ModelSerializer):
+class UniqueFieldsMixin(serializers.ModelSerializer[_MT]):
     """
     Moves `UniqueValidator`'s from the validation stage to the save stage.
     It solves the problem with nested validation for unique fields on update.

--- a/drf_writable_nested/serializers.py
+++ b/drf_writable_nested/serializers.py
@@ -1,8 +1,12 @@
+from typing import TypeVar
+
+from django.db.models import Model
 from rest_framework import serializers
 
 from .mixins import NestedCreateMixin, NestedUpdateMixin
 
+_MT = TypeVar("_MT", bound=Model)
 
-class WritableNestedModelSerializer(NestedCreateMixin, NestedUpdateMixin,
-                                    serializers.ModelSerializer):
+class WritableNestedModelSerializer(NestedCreateMixin[_MT], NestedUpdateMixin[_MT],
+                                    serializers.ModelSerializer[_MT]):
     pass

--- a/mypy.ini
+++ b/mypy.ini
@@ -8,3 +8,6 @@ django_settings_module = "example.settings"
 
 [mypy-setuptools.*]
 ignore_missing_imports = True
+
+[mypy-drf_writable_nested.*]
+disallow_any_generics = True


### PR DESCRIPTION
This enables the `disallow_any_generics` configuration in mypy and makes serializer classes generic. The motivation for this is that currently when using nested serializers, mypy doesn't know that we use the inherited (drf) serializer with a specific model due to the intermediate nested serializer class.